### PR TITLE
Rework: enhance role to support all mariadb versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,24 @@ git clone https://github.com/while-true-do/ansible-role-mariadb.git while-true-d
 
 ```yaml
 # defaults/main.yml
-wtd_mariadb_packages:
-  - MariaDB-server
-  - MariaDB-client
+wtd_mariadb_packages: []
+
+wtd_mariadb_default_packages:
+  - "mariadb"
+  - "mariadb-server"
+
+wtd_mariadb_default_repo_packages:
+  - "MariaDB-client"
+  - "MariaDB-server"
+
+wtd_mariadb_default_repo_dependent_packages:
+  - "MariaDB-common"
+  - "MariaDB-shared"
+
+wtd_mariadb_service: "mariadb"
 
 wtd_mariadb_root_password: ''
+
 wtd_mariadb_port: '3306'
 wtd_mariadb_bind_address: '0.0.0.0'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,19 @@
 ---
-wtd_mariadb_packages:
-  - MariaDB-server
-  - MariaDB-client
+wtd_mariadb_packages: []
+
+wtd_mariadb_default_packages:
+  - "mariadb"
+  - "mariadb-server"
+
+wtd_mariadb_default_repo_packages:
+  - "MariaDB-client"
+  - "MariaDB-server"
+
+wtd_mariadb_default_repo_dependent_packages:
+  - "MariaDB-common"
+  - "MariaDB-shared"
+
+wtd_mariadb_service: "mariadb"
 
 wtd_mariadb_root_password: ''
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Restart MariaDB service
   service:
-    name: mariadb
+    name: "{{ wtd_mariadb_service }}"
     state: restarted

--- a/tasks/cleanup_packages_repo_disabled.yml
+++ b/tasks/cleanup_packages_repo_disabled.yml
@@ -1,0 +1,20 @@
+---
+- name: Remove wrong MariaDB packages
+  package:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ wtd_mariadb_default_repo_packages }}"
+    - galera
+
+- name: Get if MariaDB-common is installed
+  yum:
+    list: MariaDB-common
+  register: wtd_mariadb_mariadb_common_installed
+
+- name: Swap dependent packages
+  command: yum -y swap MariaDB-common mariadb-libs
+  args:
+    warn: no
+  register: wtd_mariadb_swap_dependent_packages
+  when: wtd_mariadb_mariadb_common_installed.results | selectattr("yumstate", "match", "installed")| list | length == 1

--- a/tasks/cleanup_packages_repo_enabled.yml
+++ b/tasks/cleanup_packages_repo_enabled.yml
@@ -1,0 +1,14 @@
+---
+- name: Remove wrong MariaDB packages
+  package:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ wtd_mariadb_default_packages }}"
+
+- name: Install MariaDB dependent packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ wtd_mariadb_default_repo_dependent_packages }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,26 @@
 ---
-- name: Install MariaDB
-  package:
-    name: '{{ item }}'
-    state: present
-  with_items:
-    - '{{ wtd_mariadb_packages }}'
+- name: Select packages
+  include_tasks: select_packages.yml
+
+- name: Include cleanup MariaDB packages if repo-mariadb is enabled
+  include_tasks: cleanup_packages_repo_enabled.yml
+  when: wtd_repo_mariadb_enabled and wtd_repo_mariadb_added.changed
+
+- name: Include cleanup MariaDB packages if repo-mariadb is disabled
+  include_tasks: cleanup_packages_repo_disabled.yml
+  when: not wtd_repo_mariadb_enabled and wtd_repo_mariadb_removed.changed
 
 - name: Install ansible dependency MySQL-python
   package:
     name: MySQL-python
     state: present
+
+- name: Install MariaDB
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ wtd_mariadb_packages }}"
 
 - name: Configure /etc/my.cnf
   template:
@@ -41,7 +52,7 @@
 
 - name: Start MariaDB and enable service
   service:
-    name: mariadb
+    name: "{{ wtd_mariadb_service }}"
     state: started
     enabled: yes
 

--- a/tasks/mysql_secure_installation.yml
+++ b/tasks/mysql_secure_installation.yml
@@ -11,14 +11,14 @@
     login_user: root
     login_password: ''
     user: root
-    password: '{{ wtd_mariadb_root_password }}'
+    password: "{{ wtd_mariadb_root_password }}"
   when: wtd_mariadb_root_password_check.rc == 0
   failed_when: wtd_mariadb_root_password == ''
 
 - name: Remove anonymous users
   mysql_user:
     login_user: root
-    login_password: '{{ wtd_mariadb_root_password }}'
+    login_password: "{{ wtd_mariadb_root_password }}"
     name: ''
     host_all: yes
     state: absent
@@ -26,19 +26,19 @@
 - name: Disallow root login remotely for localhost
   mysql_user:
     login_user: root
-    login_password: '{{ wtd_mariadb_root_password }}'
+    login_password: "{{ wtd_mariadb_root_password }}"
     user: root
-    password: '{{ wtd_mariadb_root_password }}'
-    host: '{{ item }}'
+    password: "{{ wtd_mariadb_root_password }}"
+    host: "{{ item }}"
   with_items:
-    - '::1'
-    - localhost
-    - '127.0.0.1'
-    - '{{ ansible_fqdn }}'
+    - "::1"
+    - "localhost"
+    - "127.0.0.1"
+    - "{{ ansible_fqdn }}"
 
 - name: Remove test database and access to it
   mysql_db:
     login_user: root
-    login_password: '{{ wtd_mariadb_root_password }}'
+    login_password: "{{ wtd_mariadb_root_password }}"
     name: test
     state: absent

--- a/tasks/select_packages.yml
+++ b/tasks/select_packages.yml
@@ -1,0 +1,17 @@
+---
+- name: Set mariadb packages if repo-mariadb is enabled
+  set_fact:
+    wtd_mariadb_packages: "{{ wtd_mariadb_packages }} + [ '{{ item }}' ]"
+  with_items: "{{ wtd_mariadb_default_repo_packages }}"
+  when: wtd_repo_mariadb_enabled
+
+- name: Set mariadb packages if repo-mariadb is disabled
+  set_fact:
+    wtd_mariadb_packages: "{{ wtd_mariadb_packages }} + [ '{{ item }}' ]"
+  with_items: "{{ wtd_mariadb_default_packages }}"
+  when: not wtd_repo_mariadb_enabled
+
+- name: Set service name for MariaDB
+  set_fact:
+    wtd_mariadb_service: "mysql"
+  when: wtd_repo_mariadb_enabled and wtd_repo_mariadb_version == "5.5"


### PR DESCRIPTION
# Rework: enhance role to support all mariadb versions

The role now has support to setup all packages correctly.
A switch between versions after installation is not included.

## Reference

## People
@daniel-wtd : please have a look ;)
