### PR TITLE
Fix: Use shell only when shell functionality is required

### DIFF
--- a/tasks/mysql_secure_installation.yml
+++ b/tasks/mysql_secure_installation.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if MariaDB root user has a password
-  shell: mysql -u root
+  command: mysql -u root
   ignore_errors: true
   register: wtd_mariadb_root_password_check
   changed_when: wtd_mariadb_root_password_check.rc == 0


### PR DESCRIPTION
# Use shell only when shell functionality is required

use command module instead for task
tasks/mysql_secure_installation.yml:2: Check if MariaDB root user has a password

## Reference
 - Resolves: #2 

## People